### PR TITLE
OpsLevel repo catalog - upload opslevel.yml

### DIFF
--- a/opslevel.yml
+++ b/opslevel.yml
@@ -1,0 +1,5 @@
+---
+version: 1
+repository:
+  owner: iam_federations
+  tags:


### PR DESCRIPTION
### Auth0 SRE - Add `opslevel.yml` 

Adds an OpsLevel YAML definition file `opslevel.yml`. This file allows OpsLevel to automatically track ownership and metadata about CIC services and repositories.
This work supersedes manual tracking of services in OpsLevel UI and in the Google Sheet referenced below.



### References


- JIRA epic: https://auth0team.atlassian.net/browse/SRE-57
- DACI: https://oktawiki.atlassian.net/wiki/spaces/A0SRE/pages/2691870299/Repository+Catalog
- Repo ownership Google Sheet: https://docs.google.com/spreadsheets/d/1-hzi_3MysWklwhoz4lV5lYg17kcGsh9GruUOXlzzhAE/edit#gid=591959482
- OpsLevel config-as-code documentation: https://www.opslevel.com/docs/opslevel-yml
- OpsLevel YAML format: https://oktawiki.atlassian.net/wiki/spaces/A0SRE/pages/2698906834
- Slack channel: #opslevel-config-as-code

### Testing

No testing is required from you as repository owners.


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
- [ ] **Repo Owner** - Please review the team alias value for the owner key, using https://oktawiki.atlassian.net/wiki/spaces/A0SRE/pages/2698906834/OpsLevel+YAML+format#Valid-team-aliases for reference.